### PR TITLE
[Fix for #24] Removed the hover on phone 

### DIFF
--- a/public/css/navbar.css
+++ b/public/css/navbar.css
@@ -9,7 +9,7 @@
     align-items: center;
     justify-content: center;
     position: fixed;
-    z-index: 100;
+    z-index: 9999;
     top: 2rem;
 }
 
@@ -92,6 +92,24 @@ a {
     position: relative;
     border: none;
     background-color: #ffffff00;
+}
+
+.hover-underline-animation::after {
+    content: "";
+    position: absolute;
+    width: 100%;
+    transform: scaleX(0);
+    height: 2px;
+    bottom: -2px;
+    left: 0;
+    background: #c16632;
+    transform-origin: center;
+    transition: transform 0.2s ease-out;
+}
+
+.hover-underline-animation:hover::after {
+    transform: scaleX(1);
+    transform-origin: center;
 }
 
 #nav-icon3 {
@@ -268,22 +286,8 @@ a {
     .dropdown-hamburger {
         top: -5px;
     }
-}
 
-.hover-underline-animation::after {
-    content: "";
-    position: absolute;
-    width: 100%;
-    transform: scaleX(0);
-    height: 2px;
-    bottom: -2px;
-    left: 0;
-    background: #c16632;
-    transform-origin: center;
-    transition: transform 0.2s ease-out;
-}
-
-.hover-underline-animation:hover::after {
-    transform: scaleX(1);
-    transform-origin: center;
+    .hover-underline-animation:hover::after {
+        transform: scaleX(0);
+    }
 }

--- a/public/js/quality.js
+++ b/public/js/quality.js
@@ -121,6 +121,9 @@ function hideElementsOnSmallScreen() {
     if ($(window).width() < 516) {
         // here the reason it is 516 is bescuse 525-9 =516
         for (var i = 1; i < 4; i++) {
+            if(i === currentlySelected) {
+                continue;
+            }
             var chooseItem = $(`#chooseItem${i}`);
             chooseItem.css("display", "none");
         }


### PR DESCRIPTION
## Description
This PR addresses issue #24. I have fixed the issue with the navbar hover effect showing on phone

## Changes made
I added a line in the css break point to not transform when hover. I also fixed an issue where on phone the quality section titles do not display. I have not fixed the expanded hamburger showing when clicking back on mobile as it is normal behavior.